### PR TITLE
Support multiple doors

### DIFF
--- a/door_adapter_template/config.yaml
+++ b/door_adapter_template/config.yaml
@@ -2,14 +2,15 @@
 # RMF door parameters
 
 ### template ###
-door:
-  name: "example_door"
-  api_endpoint: "http://127.0.0.1:8888/"
-  header_key: "example_key"
-  header_value: "example_header_value"
-  door_id: "example_door_id"
-  door_signal_period: 3.0 # Seconds
-  door_close_feature: False 
+doors:
+  "door_1":  # door name and id
+    door_close_feature: False
+    door_signal_period: 3.0 # Seconds
+    enable_check_status: False # Whether to keep checking door state when there are no requests
+  "door_2":  # door name and id
+    door_close_feature: False
+    door_signal_period: 3.0 # Seconds
+    enable_check_status: False # Whether to keep checking door state when there are no requests
 
 door_subscriber:
   topic_name: "adapter_door_requests"
@@ -17,3 +18,10 @@ door_subscriber:
 door_publisher:
   topic_name: "door_states"
   door_state_publish_period: 1.0 # Seconds
+
+mock: False
+
+# Sample creds:
+api_endpoint: "http://127.0.0.1:8888/"
+header_key: "example_key"
+header_value: "example_header_value"

--- a/door_adapter_template/config.yaml
+++ b/door_adapter_template/config.yaml
@@ -4,13 +4,14 @@
 ### template ###
 doors:
   "door_1":  # door name and id
-    door_close_feature: False
-    door_signal_period: 3.0 # Seconds
-    enable_check_status: False # Whether to keep checking door state when there are no requests
+    door_auto_closes: True # Set to True if door remains closed until requested open, and automatically closes if it does not receive subsequent open requests.
+    door_signal_period: 3.0 # Time taken for door signal to be effective, in seconds.
+    continuous_status_polling: False # Whether to keep checking door state when there are no requests
+    # NOTE: door_close_feature is [DEPRECATED], use door_auto_closes instead
   "door_2":  # door name and id
-    door_close_feature: False
-    door_signal_period: 3.0 # Seconds
-    enable_check_status: False # Whether to keep checking door state when there are no requests
+    door_auto_closes: True # Set to True if door remains closed until requested open, and automatically closes if it does not receive subsequent open requests.
+    door_signal_period: 3.0 # # Time taken for door signal to be effective, in seconds.
+    continuous_status_polling: False # Whether to keep checking door state when there are no requests
 
 door_subscriber:
   topic_name: "adapter_door_requests"

--- a/door_adapter_template/door_adapter_template/DoorClientAPI.py
+++ b/door_adapter_template/door_adapter_template/DoorClientAPI.py
@@ -1,20 +1,19 @@
-import requests
-import json
-import urllib3
-import socket
 import time
 from rmf_door_msgs.msg import DoorMode
 
 class DoorClientAPI:
-    def __init__(self,url,api_key,api_value,door_id):
-        self.url = url
-        self.header = {api_key:api_value}
-        self.data = {"id": door_id}
+    def __init__(self, node, config):
+        self.name = 'rmf_door_adapter'
+        self.timeout = 5  # seconds
+        self.debug = False
+        self.connected = False
+        self.node = node
+        self.config = config  # use this config to establish connection
 
         count = 0
         self.connected = True
         while not self.check_connection():
-            if count >= 5:
+            if count >= self.timeout:
                 print("Unable to connect to door client API.")
                 self.connected = False
                 break
@@ -30,21 +29,21 @@ class DoorClientAPI:
         ## ------------------------ ##
         return False
 
-    def open_door(self):
+    def open_door(self, door_id):
         ''' Return True if the door API server is successful receive open door command'''
         ## ------------------------ ##
         ## IMPLEMENT YOUR CODE HERE ##
         ## ------------------------ ##
         return False
 
-    def close_door(self):
+    def close_door(self, door_id):
         ''' Return True if the door API server is successful receive open door command'''
         ## ------------------------ ##
         ## IMPLEMENT YOUR CODE HERE ##
         ## ------------------------ ##
         return False
 
-    def get_mode(self):
+    def get_mode(self, door_id):
         ''' Return the door status with reference rmf_door_msgs. 
             Return DoorMode.MODE_CLOSED when door status is closed.
             Return DoorMode.MODE_MOVING when door status is moving.

--- a/door_adapter_template/door_adapter_template/door_adapter.py
+++ b/door_adapter_template/door_adapter_template/door_adapter.py
@@ -52,7 +52,7 @@ class DoorAdapter(Node):
                 self.doors[door_id] = Door(door_id,
                                            door_data['door_close_feature'],
                                            door_data['door_signal_period'],
-                                           door_data.get('enable_check_status', None))
+                                           door_data.get('enable_check_status', False))
 
         self.door_states_pub = self.create_publisher(
             DoorState, door_pub['topic_name'], 100)

--- a/door_adapter_template/door_adapter_template/door_adapter.py
+++ b/door_adapter_template/door_adapter_template/door_adapter.py
@@ -49,8 +49,16 @@ class DoorAdapter(Node):
             # Keep track of doors
             self.doors = {}
             for door_id, door_data in config_yaml['doors'].items():
+                # We support both door_auto_closes and the deprecated
+                # door_close_feature for backward compatibility
+                auto_close = door_data.get('door_auto_closes', None)
+                if auto_close is None:
+                    if 'door_close_feature' in door_data:
+                        auto_close = not door_data['door_close_feature']
+                assert auto_close is not None
+
                 self.doors[door_id] = Door(door_id,
-                                           door_data['door_auto_closes'],
+                                           auto_close,
                                            door_data['door_signal_period'],
                                            door_data.get('continuous_status_polling', False))
 

--- a/example/door_adapter/DoorClientAPI.py
+++ b/example/door_adapter/DoorClientAPI.py
@@ -1,19 +1,22 @@
 import requests
-import json
 import urllib3
 import socket
 import time
+from rmf_door_msgs.msg import DoorMode
 
 class DoorClientAPI:
-    def __init__(self,url,api_key,api_value,door_id):
-        self.url = url
-        self.header = {api_key:api_value}
-        self.data = {"id": door_id}
+    def __init__(self, node, config):
+        self.name = 'rmf_door_adapter'
+        self.timeout = 5  # seconds
+        self.debug = False
+        self.connected = False
+        self.node = node
+        self.config = config  # use this config to establish connection
 
         count = 0
         self.connected = True
         while not self.check_connection():
-            if count >= 5:
+            if count >= self.timeout:
                 print("Unable to connect to door client API.")
                 self.connected = False
                 break
@@ -32,9 +35,9 @@ class DoorClientAPI:
             print(f"Connection Error: {e}")
             return False
 
-    def open_door(self):
+    def open_door(self, door_id):
         try:
-            response = requests.post(url=self.url+"/door/remoteopen",headers=self.header, json=self.data, timeout=1.0)
+            response = requests.post(url=self.url+f"/door/remoteopen/{door_id}",headers=self.header, json=self.data, timeout=1.0)
             if response:
                 result = response.json()["body"]
                 if (result.get("result") is not None):
@@ -49,24 +52,23 @@ class DoorClientAPI:
             print("Connection Error. "+str(e))
             return False
 
-    def get_mode(self):
+    def get_mode(self, door_id):
         try:
-            response = requests.post(url=self.url+"/door/status", headers=self.header, json=self.data, timeout=1.0) 
+            response = requests.post(url=self.url+f"/door/status/{door_id}", headers=self.header, json=self.data, timeout=1.0) 
             if response:
                 state = response.json().get("body").get("doorState")
                 if state is None:
-                    return 4
+                    return DoorMode.MODE_UNKNOWN
                 elif state == "closed":
-                    return 0
+                    return DoorMode.MODE_CLOSED
                 elif state == "betweenOpenandClosed ":
-                    return 1
+                    return DoorMode.MODE_MOVING
                 elif state == "open":
-                    return 2
+                    return DoorMode.MODE_OPEN
                 elif state == "OFFLINE":
-                    return 3
+                    return DoorMode.MODE_OFFLINE
             else:
                 return 4
         except (socket.gaierror, urllib3.exceptions.NewConnectionError, urllib3.exceptions.MaxRetryError, requests.exceptions.HTTPError ,requests.exceptions.ReadTimeout, requests.exceptions.ConnectionError) as e:
             print("Connection Error. "+str(e))
-            return 4
-            
+            return DoorMode.MODE_UNKNOWN

--- a/example/door_adapter/door_adapter.py
+++ b/example/door_adapter/door_adapter.py
@@ -52,7 +52,7 @@ class DoorAdapter(Node):
                 self.doors[door_id] = Door(door_id,
                                            door_data['door_close_feature'],
                                            door_data['door_signal_period'],
-                                           door_data.get('enable_check_status', None))
+                                           door_data.get('enable_check_status', False))
 
         self.door_states_pub = self.create_publisher(
             DoorState, door_pub['topic_name'], 100)


### PR DESCRIPTION
This PR updates the door adapter template to support multiple door management. In addition, it makes the `check_status` feature optional and configurable. With the current default behavior, the door adapter will assume that the door is always closed if the latest door request is a `close` request, and the door status is `closed`. This was meant to reduce the number of unnecessary APIs called in between `open` requests. However, in our deployment we've found that some users would like to observe door statuses even if they're not in use by RMF. With this PR, this feature can be toggled on or off via the `enable_check_status` field in the door adapter config.